### PR TITLE
Caches FanArt Images in Cloudinary

### DIFF
--- a/functions/daily.js
+++ b/functions/daily.js
@@ -27,7 +27,7 @@ exports.handler = async (event, context) => {
       }
 
       if (typeof artistData.data.artistthumb !== 'undefined') {
-        cleanArtists[i].fields.image = artistData.data.artistthumb[0].url
+        cleanArtists[i].fields.image = artistData.data.artistthumb[0].url.replace('https://assets.fanart.tv/fanart/', 'https://res.cloudinary.com/dixwznarl/image/upload/c_scale,q_auto,w_400/fanart/')
       }
       
     }


### PR DESCRIPTION
Uses Cloudinary and the transformation capability to cache the large FanArt.tv images, resize them to something closer to the max size seen on the page, optimizes the image, then serves it through Cloudinary's CDN.